### PR TITLE
Fix: "TypeError: Assignment to constant variable."

### DIFF
--- a/src/Language/PureScript/PSString.js
+++ b/src/Language/PureScript/PSString.js
@@ -1,7 +1,7 @@
 export const decodeUtf16BEImpl = (arrayOfUt16CodeUnits) => {
   const arrayBuf = new ArrayBuffer(2 * arrayOfUt16CodeUnits.length);
   const dataBuf = new DataView(arrayBuf);
-  for (const i = 0; i < arrayOfUt16CodeUnits.length; i++) {
+  for (let i = 0; i < arrayOfUt16CodeUnits.length; i++) {
     dataBuf.setUint16(2 * i, arrayOfUt16CodeUnits[i], false);
   }
   const decoder = new TextDecoder("utf-16be", { fatal: true, ignoreBOM: false });


### PR DESCRIPTION
Ran into this while working on spago:

```console
TypeError: Assignment to constant variable.
    at Module.decodeUtf16BEImpl 
(file:///Users/chuck/repos/spago/output/Language.PureScript.PSString/foreign.js:4:55)

```